### PR TITLE
feat: testing e2e

### DIFF
--- a/.github/e2e/resources/authgw/htdigest
+++ b/.github/e2e/resources/authgw/htdigest
@@ -1,0 +1,1 @@
+e2e-digest-user:ikanos-e2e:72834cdd5c4fca9b336ec8985d2f36ce

--- a/.github/e2e/resources/authgw/htpasswd
+++ b/.github/e2e/resources/authgw/htpasswd
@@ -1,0 +1,2 @@
+e2e-basic-user:$apr1$e2eSalt1$tuao4FDP3IEf3a/i3czFd1
+e2e-basic-nopass-user:$apr1$e2eSalt2$uBY.QAp39bH8Cw04iSeIs0

--- a/.github/e2e/resources/authgw/httpd.conf
+++ b/.github/e2e/resources/authgw/httpd.conf
@@ -1,0 +1,157 @@
+# authgw — Apache httpd acting as an authenticating reverse proxy in front of
+# Microcks.
+#
+# Why this exists: Microcks dispatches on request *content* (URI parts, query
+# params, body) and has no notion of rejecting a request whose credentials are
+# missing or wrong. A consumed-auth E2E test against Microcks alone would pass
+# even if Ikanos sent no credential at all. This gateway enforces the auth, then
+# proxies to Microcks so the payloads stay spec-driven.
+#
+# One vhost per consumed authentication type — the capability under test only
+# changes its `baseUri` port:
+#
+#   :8090  basic   → mod_auth_basic  (htpasswd)
+#   :8091  apikey  → mod_rewrite     (X-Api-Key header or api_key query param)
+#   :8092  digest  → mod_auth_digest (htdigest, full RFC 2617 handshake)
+#   :8093  apikey  → mod_rewrite     (raw token in Authorization, no scheme)
+#
+# Every vhost also serves an unauthenticated /authgw-health used by the workflow
+# to wait for readiness.
+
+ServerName authgw
+
+Listen 8090
+Listen 8091
+Listen 8092
+Listen 8093
+
+LoadModule mpm_event_module   modules/mod_mpm_event.so
+LoadModule authn_file_module  modules/mod_authn_file.so
+LoadModule authn_core_module  modules/mod_authn_core.so
+LoadModule authz_host_module  modules/mod_authz_host.so
+LoadModule authz_user_module  modules/mod_authz_user.so
+LoadModule authz_core_module  modules/mod_authz_core.so
+LoadModule auth_basic_module  modules/mod_auth_basic.so
+LoadModule auth_digest_module modules/mod_auth_digest.so
+LoadModule headers_module     modules/mod_headers.so
+LoadModule rewrite_module     modules/mod_rewrite.so
+LoadModule proxy_module       modules/mod_proxy.so
+LoadModule proxy_http_module  modules/mod_proxy_http.so
+LoadModule alias_module       modules/mod_alias.so
+LoadModule mime_module        modules/mod_mime.so
+LoadModule log_config_module  modules/mod_log_config.so
+LoadModule unixd_module       modules/mod_unixd.so
+LoadModule dir_module         modules/mod_dir.so
+
+User daemon
+Group daemon
+
+ErrorLog /proc/self/fd/2
+LogLevel warn
+LogFormat "%h %t \"%r\" %>s %b" common
+CustomLog /proc/self/fd/1 common
+
+TypesConfig conf/mime.types
+DocumentRoot "/usr/local/apache2/htdocs"
+
+<Directory "/usr/local/apache2/htdocs">
+    Require all granted
+</Directory>
+
+# Forward proxying stays off — this is a reverse proxy only.
+ProxyRequests Off
+ProxyPreserveHost Off
+
+
+# ── :8090 — HTTP Basic ────────────────────────────────────────────────────────
+<VirtualHost *:8090>
+    ProxyPass        /authgw-health !
+    Alias            /authgw-health /usr/local/apache2/htdocs/index.html
+
+    ProxyPass        / http://microcks:8080/
+    ProxyPassReverse / http://microcks:8080/
+
+    # Only the Microcks mock endpoints are protected; /authgw-health stays open.
+    <Location "/rest/">
+        AuthType Basic
+        AuthName "ikanos-e2e"
+        AuthBasicProvider file
+        AuthUserFile /usr/local/apache2/conf/auth/htpasswd
+        Require valid-user
+    </Location>
+</VirtualHost>
+
+
+# ── :8091 — API key ───────────────────────────────────────────────────────────
+# httpd has no API-key auth module, so this is done with mod_rewrite. The key is
+# accepted either as an X-Api-Key request header or as an api_key query
+# parameter, which covers both `placement:` values of the ikanos apikey spec.
+#
+# NOTE: the api_key query parameter is forwarded to Microcks as-is. Use the
+# query placement only against operations whose Microcks dispatcher does not
+# read the query string (URI_PARTS ones such as get-ship). Operations dispatched
+# with URI_PARAMS (list-ships) must use the header placement.
+<VirtualHost *:8091>
+    ProxyPass        /authgw-health !
+    Alias            /authgw-health /usr/local/apache2/htdocs/index.html
+
+    ProxyPass        / http://microcks:8080/
+    ProxyPassReverse / http://microcks:8080/
+
+    RewriteEngine On
+
+    # Readiness endpoint bypasses the key check.
+    RewriteRule ^/authgw-health - [L]
+
+    # Reject only when the key is in neither place (conditions are ANDed).
+    RewriteCond %{HTTP:X-Api-Key} !=e2e-apikey-value
+    RewriteCond %{QUERY_STRING} !(^|&)api_key=e2e-apikey-value($|&)
+    RewriteRule ^ - [R=401,L]
+
+    Header always set WWW-Authenticate "ApiKey realm=\"ikanos-e2e\"" "expr=%{REQUEST_STATUS} == 401"
+</VirtualHost>
+
+
+# ── :8092 — HTTP Digest ───────────────────────────────────────────────────────
+# mod_auth_digest performs the real challenge–response handshake: the first
+# request is answered with 401 + WWW-Authenticate: Digest (realm, nonce, qop),
+# and the client must return a correctly computed response hash. The realm here
+# MUST match the realm baked into the htdigest file.
+<VirtualHost *:8092>
+    ProxyPass        /authgw-health !
+    Alias            /authgw-health /usr/local/apache2/htdocs/index.html
+
+    ProxyPass        / http://microcks:8080/
+    ProxyPassReverse / http://microcks:8080/
+
+    <Location "/rest/">
+        AuthType Digest
+        AuthName "ikanos-e2e"
+        AuthDigestProvider file
+        AuthDigestDomain /rest/
+        AuthUserFile /usr/local/apache2/conf/auth/htdigest
+        Require valid-user
+    </Location>
+</VirtualHost>
+
+
+# ── :8093 — raw token in the Authorization header ─────────────────────────────
+# Models the APIs that expect the credential in Authorization with NO scheme
+# prefix. The `apikey` auth type exists precisely to say
+# "put this exact value in this exact header", and Authorization is the header
+# name that matters most.
+<VirtualHost *:8093>
+    ProxyPass        /authgw-health !
+    Alias            /authgw-health /usr/local/apache2/htdocs/index.html
+
+    ProxyPass        / http://microcks:8080/
+    ProxyPassReverse / http://microcks:8080/
+
+    RewriteEngine On
+
+    RewriteRule ^/authgw-health - [L]
+
+    RewriteCond %{HTTP:Authorization} !=e2e-raw-token-value
+    RewriteRule ^ - [R=401,L]
+    Header always set WWW-Authenticate "ApiKey realm=\"ikanos-e2e\"" "expr=%{REQUEST_STATUS} == 401"
+</VirtualHost>

--- a/.github/e2e/resources/docker-compose.yml
+++ b/.github/e2e/resources/docker-compose.yml
@@ -17,6 +17,28 @@ services:
     networks:
       - e2e
 
+  # Authenticating reverse proxy in front of Microcks, used by the consumed-auth
+  # feature. Microcks cannot reject a request on missing or wrong credentials,
+  # so the auth is enforced here while the payloads still come from the OpenAPI
+  # specs. See authgw/httpd.conf one vhost per auth type.
+  authgw:
+    image: httpd:2.4
+    container_name: e2e-authgw
+    depends_on:
+      microcks:
+        condition: service_healthy
+    ports:
+      - "8090:8090"   # basic
+      - "8091:8091"   # apikey
+      - "8092:8092"   # digest
+      - "8093:8093"   # apikey, raw token in Authorization
+    volumes:
+      - ./authgw/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro
+      - ./authgw/htpasswd:/usr/local/apache2/conf/auth/htpasswd:ro
+      - ./authgw/htdigest:/usr/local/apache2/conf/auth/htdigest:ro
+    networks:
+      - e2e
+
   keycloak:
     image: quay.io/keycloak/keycloak:26.1
     container_name: e2e-keycloak

--- a/.github/e2e/resources/features/_lib/helpers.sh
+++ b/.github/e2e/resources/features/_lib/helpers.sh
@@ -59,7 +59,16 @@ _wait_for_mcp() {
       -H "Authorization: Bearer $TOKEN" \
       -H "MCP-Protocol-Version: $MCP_VERSION" \
       -H "Mcp-Method: tools/list" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"tools/list\",\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\"$MCP_VERSION\"}}}" \
+      -d '{
+        "jsonrpc":"2.0",
+        "id":0,
+        "method":"tools/list",
+        "params": {
+          "_meta": {
+            "io.modelcontextprotocol/protocolVersion": "'"$MCP_VERSION"'"
+          }
+        }
+      }' \
       2>/dev/null || true)
     if echo "$RESP" | jq -e '.result.tools' > /dev/null 2>&1; then
       echo "  MCP server is ready on port $PORT"; return 0
@@ -210,6 +219,41 @@ run_auth_test() {
     PASSED=$((PASSED + 1))
   else
     echo "  FAIL ✗ — expected HTTP $EXPECTED_STATUS, got $HTTP_STATUS"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# run_mcp_expect_error NAME TOOL PORT ARGS TOKEN
+# Calls tools/call and asserts the call came back as an error.
+#
+# Use for negative paths where the *upstream* is expected to reject the
+# credentials Ikanos sends. The MCP surface itself still authenticates fine, so
+# the failure has to surface inside the JSON-RPC response (result.isError, or a
+# top-level error) rather than as an HTTP status on the MCP port
+run_mcp_expect_error() {
+  local NAME="$1" TOOL="$2" PORT="$3" ARGS="$4" TOKEN="$5"
+
+  echo ""
+  echo "  Test: $NAME  (type: mcp, expecting an error, tool: $TOOL, port: $PORT)"
+
+  # See run_mcp_test for why `|| true` is required here.
+  local RESPONSE IS_ERROR
+  RESPONSE=$(curl -s "http://localhost:$PORT" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "MCP-Protocol-Version: $MCP_PROTOCOL_VERSION" \
+    -H "Mcp-Method: tools/call" \
+    -H "Mcp-Name: $TOOL" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$TOOL\",\"arguments\":$ARGS,\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\"$MCP_PROTOCOL_VERSION\"}}}" || true)
+
+  IS_ERROR=$(echo "$RESPONSE" | jq -r '.result.isError // false')
+
+  if [ "$IS_ERROR" = "true" ] || echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
+    echo "  PASS ✓ — $NAME (upstream rejection surfaced as an error)"
+    PASSED=$((PASSED + 1))
+  else
+    echo "  FAIL ✗ — expected an error, got a successful result"
+    echo "    Response: $(echo "$RESPONSE" | jq -c '.result // .')"
     FAILED=$((FAILED + 1))
   fi
 }

--- a/.github/e2e/resources/features/consumed-auth/capability.yml
+++ b/.github/e2e/resources/features/consumed-auth/capability.yml
@@ -1,0 +1,481 @@
+ikanos: "1.0.0-beta3"
+
+# Consumed-side authentication — basic, apikey and digest in one capability.
+#
+# These are three variants of a single feature (does Ikanos actually send the
+# credentials it was configured with?), so they live in one folder and run on
+# one Ikanos instance.
+#
+# The upstream is always Microcks, reached through the authgw reverse proxy
+# (see .github/e2e/resources/authgw/httpd.conf), which enforces the auth that
+# Microcks itself cannot:
+#
+#   :8090  basic   mod_auth_basic
+#   :8091  apikey  mod_rewrite  (X-Api-Key header or api_key query param)
+#   :8092  digest  mod_auth_digest, full RFC 2617 handshake
+#
+# Every auth type is declared twice — once with correct credentials, once with
+# deliberately wrong ones. The negative half is what gives the positive half its
+# meaning: without it, the tests would also pass against an upstream that
+# ignores authentication entirely, which is exactly the trap Microcks alone sets.
+#
+# ⚠️ THE DIGEST TOOLS ARE FAILING TODAY. HttpClientAdapter builds a
+# ChallengeResponse(HTTP_DIGEST) carrying only identifier and secret, never
+# retries on 401, and the Restlet helper able to serialise a digest header
+# (org.restlet.ext.crypto) is not even a dependency — the core jar ships only
+# HttpBasicHelper. So the request leaves unauthenticated, Apache answers 401
+# with an HTML error page, and that HTML reaches the JSON parser.
+
+binds:
+- namespace: "authgw-env"
+  description: "Credentials expected by the authgw vhosts, and their wrong counterparts."
+  location: "file:///app/shared/secrets.yaml"
+  keys:
+    BASIC_USER: "authgw-basic-user"
+    BASIC_PASSWORD: "authgw-basic-password"
+    API_KEY: "authgw-apikey"
+    RAW_AUTHORIZATION_KEY: "authgw-authorization-key"
+    DIGEST_USER: "authgw-digest-user"
+    DIGEST_PASSWORD: "authgw-digest-password"
+    BAD_USER: "authgw-bad-user"
+    BAD_PASSWORD: "authgw-bad-password"
+    BAD_API_KEY: "authgw-bad-apikey"
+    BASIC_NOPASS_USER: "authgw-basic-nopass-user"
+- namespace: "bearer-env"
+  description: "Static bearer token for the MCP surface."
+  location: "file:///app/shared/secrets.yaml"
+  keys:
+    MCP_BEARER_TOKEN: "mcp-server-token"
+
+capability:
+  consumes:
+
+  # ── basic ───────────────────────────────────────────────────────────────────
+  - namespace: registry-basic
+    description: "Registry behind the authgw basic vhost."
+    type: http
+    baseUri: "http://localhost:8090/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    authentication:
+      type: basic
+      username: "{{BASIC_USER}}"
+      password: "{{BASIC_PASSWORD}}"
+    resources:
+      ships:
+        path: "/ships"
+        operations:
+          list-ships:
+            method: GET
+            inputParameters:
+              status:
+                in: query
+      ship:
+        path: "/ships/{{imo_number}}"
+        operations:
+          get-ship:
+            method: GET
+            inputParameters:
+              imo_number:
+                in: path
+
+  # Regression test for naftiko/ikanos#707: `password` is deliberately absent
+  # (not empty-string — absent), which used to NPE in
+  # HttpClientAdapter.setChallengeResponse() instead of sending an empty
+  # password. The authgw account behind this vhost has an empty password
+  # (see authgw/htpasswd), so this only succeeds if the fix actually sends one.
+  - namespace: registry-basic-nopass
+    description: "Same upstream, username only — password field omitted entirely (#707 regression)."
+    type: http
+    baseUri: "http://localhost:8090/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    authentication:
+      type: basic
+      username: "{{BASIC_NOPASS_USER}}"
+    resources:
+      ships:
+        path: "/ships"
+        operations:
+          list-ships:
+            method: GET
+
+  - namespace: registry-basic-bad
+    description: "Same upstream, wrong password — must be rejected 401."
+    type: http
+    baseUri: "http://localhost:8090/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    authentication:
+      type: basic
+      username: "{{BAD_USER}}"
+      password: "{{BAD_PASSWORD}}"
+    resources:
+      ships:
+        path: "/ships"
+        operations:
+          list-ships:
+            method: GET
+
+  # ── apikey ──────────────────────────────────────────────────────────────────
+  # Two placements, deliberately paired with different operations.
+  # The api_key query parameter is forwarded to Microcks as-is, so the query
+  # placement is used on get-ship (dispatched URI_PARTS, on the path) where the
+  # extra parameter is harmless. list-ships is dispatched URI_PARAMS on `status`
+  # and therefore uses the header placement.
+  - namespace: registry-apikey-header
+    description: "Registry behind the authgw apikey vhost, key in a header."
+    type: http
+    baseUri: "http://localhost:8091/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    authentication:
+      type: apikey
+      key: "X-Api-Key"
+      value: "{{API_KEY}}"
+      placement: header
+    resources:
+      ships:
+        path: "/ships"
+        operations:
+          list-ships:
+            method: GET
+            inputParameters:
+              status:
+                in: query
+
+  - namespace: registry-apikey-query
+    description: "Registry behind the authgw apikey vhost, key in the query string."
+    type: http
+    baseUri: "http://localhost:8091/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    authentication:
+      type: apikey
+      key: "api_key"
+      value: "{{API_KEY}}"
+      placement: query
+    resources:
+      ship:
+        path: "/ships/{{imo_number}}"
+        operations:
+          get-ship:
+            method: GET
+            inputParameters:
+              imo_number:
+                in: path
+
+  # RED : regression test for the apikey/Authorization bug.
+  #
+  # The apikey branch of HttpClientAdapter writes the header through
+  # clientRequest.getHeaders().add(key, value). Restlet reserves Authorization
+  # (HeaderUtils.STANDARD_HEADERS, matched case-insensitively, 56 names in all)
+  # and refuses the addition with:
+  #
+  #   WARN  Addition of the standard header "Authorization" is not allowed.
+  #         Please use the equivalent property in the Restlet API.
+  #
+  # The return value is never checked, so the engine carries on and the request
+  # leaves with no credential. The :8093 vhost then answers 401 with an HTML
+  # error page, and that HTML reaches the JSON parser:
+  - namespace: registry-apikey-authorization
+    description: "Registry behind a vhost expecting a raw, scheme-less Authorization header."
+    type: http
+    baseUri: "http://localhost:8093/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    authentication:
+      type: apikey
+      key: "Authorization"
+      value: "{{RAW_AUTHORIZATION_KEY}}"
+      placement: header
+    resources:
+      ships:
+        path: "/ships"
+        operations:
+          list-ships:
+            method: GET
+
+  - namespace: registry-apikey-bad
+    description: "Same upstream, wrong key — must be rejected 401."
+    type: http
+    baseUri: "http://localhost:8091/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    authentication:
+      type: apikey
+      key: "X-Api-Key"
+      value: "{{BAD_API_KEY}}"
+      placement: header
+    resources:
+      ships:
+        path: "/ships"
+        operations:
+          list-ships:
+            method: GET
+
+  # ── digest ──────────────────────────────────────────────────────────────────
+  - namespace: registry-digest
+    description: "Registry behind the authgw digest vhost (realm ikanos-e2e)."
+    type: http
+    baseUri: "http://localhost:8092/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    authentication:
+      type: digest
+      username: "{{DIGEST_USER}}"
+      password: "{{DIGEST_PASSWORD}}"
+    resources:
+      ships:
+        path: "/ships"
+        operations:
+          list-ships:
+            method: GET
+            inputParameters:
+              status:
+                in: query
+      ship:
+        path: "/ships/{{imo_number}}"
+        operations:
+          get-ship:
+            method: GET
+            inputParameters:
+              imo_number:
+                in: path
+
+  - namespace: registry-digest-bad
+    description: "Same upstream, wrong password — the digest hash must not verify."
+    type: http
+    baseUri: "http://localhost:8092/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    authentication:
+      type: digest
+      username: "{{BAD_USER}}"
+      password: "{{BAD_PASSWORD}}"
+    resources:
+      ships:
+        path: "/ships"
+        operations:
+          list-ships:
+            method: GET
+
+  exposes:
+  - type: mcp
+    address: "0.0.0.0"
+    port: 3003
+    namespace: consumed-auth-tools
+    authentication:
+      type: bearer
+      token: "{{MCP_BEARER_TOKEN}}"
+    description: "One tool per consumed authentication type, plus its negative counterpart"
+    tools:
+
+      # ── basic ──
+      basic-list-ships:
+        description: "List ships through a basic-authenticated upstream"
+        inputParameters:
+          status:
+            type: string
+            required: false
+            description: "Filter by operational status"
+        call: registry-basic.list-ships
+        with:
+          status: consumed-auth-tools.status
+        outputParameters:
+        - type: array
+          mapping: "$."
+          items:
+            type: object
+            properties:
+              imo:
+                type: string
+                mapping: "$.imo_number"
+              name:
+                type: string
+                mapping: "$.vessel_name"
+              status:
+                type: string
+                mapping: "$.operational_status"
+
+      basic-get-ship:
+        description: "Retrieve one ship through a basic-authenticated upstream"
+        inputParameters:
+          imo:
+            type: string
+            required: true
+            description: "IMO number of the ship"
+        call: registry-basic.get-ship
+        with:
+          imo_number: consumed-auth-tools.imo
+        outputParameters:
+        - type: object
+          properties:
+            imo:
+              type: string
+              mapping: "$.imo_number"
+            name:
+              type: string
+              mapping: "$.vessel_name"
+            status:
+              type: string
+              mapping: "$.operational_status"
+
+      basic-nopass-list-ships:
+        description: "List ships through a basic-authenticated upstream whose password is omitted (#707 regression)"
+        call: registry-basic-nopass.list-ships
+        outputParameters:
+        - type: array
+          mapping: "$."
+          items:
+            type: object
+            properties:
+              imo:
+                type: string
+                mapping: "$.imo_number"
+              name:
+                type: string
+                mapping: "$.vessel_name"
+              status:
+                type: string
+                mapping: "$.operational_status"
+
+      basic-bad-credentials:
+        description: "Negative path — upstream rejects the basic credentials (401)"
+        call: registry-basic-bad.list-ships
+        outputParameters:
+        - type: array
+          mapping: "$."
+          items:
+            type: object
+            properties:
+              imo:
+                type: string
+                mapping: "$.imo_number"
+
+      # ── apikey ──
+      apikey-header-list-ships:
+        description: "List ships, key sent as the X-Api-Key header"
+        inputParameters:
+          status:
+            type: string
+            required: false
+            description: "Filter by operational status"
+        call: registry-apikey-header.list-ships
+        with:
+          status: consumed-auth-tools.status
+        outputParameters:
+        - type: array
+          mapping: "$."
+          items:
+            type: object
+            properties:
+              imo:
+                type: string
+                mapping: "$.imo_number"
+              name:
+                type: string
+                mapping: "$.vessel_name"
+              status:
+                type: string
+                mapping: "$.operational_status"
+
+      apikey-query-get-ship:
+        description: "Retrieve one ship, key sent as the api_key query parameter"
+        inputParameters:
+          imo:
+            type: string
+            required: true
+            description: "IMO number of the ship"
+        call: registry-apikey-query.get-ship
+        with:
+          imo_number: consumed-auth-tools.imo
+        outputParameters:
+        - type: object
+          properties:
+            imo:
+              type: string
+              mapping: "$.imo_number"
+            name:
+              type: string
+              mapping: "$.vessel_name"
+            status:
+              type: string
+              mapping: "$.operational_status"
+
+      apikey-authorization-list-ships:
+        description: "List ships, raw token sent in the Authorization header (red : see registry-apikey-authorization)"
+        call: registry-apikey-authorization.list-ships
+        outputParameters:
+        - type: array
+          mapping: "$."
+          items:
+            type: object
+            properties:
+              imo:
+                type: string
+                mapping: "$.imo_number"
+              name:
+                type: string
+                mapping: "$.vessel_name"
+              status:
+                type: string
+                mapping: "$.operational_status"
+
+      apikey-bad-key:
+        description: "Negative path — upstream rejects the API key (401)"
+        call: registry-apikey-bad.list-ships
+        outputParameters:
+        - type: array
+          mapping: "$."
+          items:
+            type: object
+            properties:
+              imo:
+                type: string
+                mapping: "$.imo_number"
+
+      # ── digest ──
+      digest-list-ships:
+        description: "List ships through a digest-authenticated upstream"
+        inputParameters:
+          status:
+            type: string
+            required: false
+            description: "Filter by operational status"
+        call: registry-digest.list-ships
+        with:
+          status: consumed-auth-tools.status
+        outputParameters:
+        - type: array
+          mapping: "$."
+          items:
+            type: object
+            properties:
+              imo:
+                type: string
+                mapping: "$.imo_number"
+              name:
+                type: string
+                mapping: "$.vessel_name"
+              status:
+                type: string
+                mapping: "$.operational_status"
+
+      digest-get-ship:
+        description: "Retrieve one ship through a digest-authenticated upstream"
+        inputParameters:
+          imo:
+            type: string
+            required: true
+            description: "IMO number of the ship"
+        call: registry-digest.get-ship
+        with:
+          imo_number: consumed-auth-tools.imo
+        outputParameters:
+        - type: object
+          properties:
+            imo:
+              type: string
+              mapping: "$.imo_number"
+            name:
+              type: string
+              mapping: "$.vessel_name"
+            status:
+              type: string
+              mapping: "$.operational_status"
+
+      digest-bad-credentials:
+        description: "Negative path — digest hash does not verify (401)"
+        call: registry-digest-bad.list-ships
+        outputParameters:
+        - type: array
+          mapping: "$."
+          items:
+            type: object
+            properties:
+              imo:
+                type: string
+                mapping: "$.imo_number"

--- a/.github/e2e/resources/features/consumed-auth/run.sh
+++ b/.github/e2e/resources/features/consumed-auth/run.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# run.sh — E2E tests for consumed-auth (basic, apikey, digest)
+#
+# Called by the workflow with these env vars already set:
+#   IKANOS_IMAGE, IKANOS_CONTAINER, SECRETS_DIR, KC_CLIENT_SECRET, MCP_SERVER_TOKEN
+# The workflow starts ikanos before calling this script and stops it after.
+#
+# Upstream is Microcks behind the authgw reverse proxy — :8090 basic,
+# :8091 apikey, :8092 digest. See authgw/httpd.conf.
+#
+# Each auth type is tested as a pair: the same operation with correct
+# credentials (must succeed) and with wrong ones (must be rejected). Neither
+# half proves anything alone — the pair is the assertion.
+#
+# ⚠️ THE DIGEST BLOCK FAILS until HttpClientAdapter answers the
+# 401 challenge. See the header of capability.yml. The failure surfaces as
+# "Unexpected character ('<')" — that is Apache's HTML 401 page reaching the
+# JSON parser, not a flake.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_lib/helpers.sh"
+
+PORT=3003
+
+echo "================================================================"
+echo "Feature: consumed-auth (basic + apikey + digest)"
+echo "================================================================"
+
+# ── 1. Obtain credentials ─────────────────────────────────────────────
+# Only the MCP surface needs a token here — the consumed-side credentials live
+# in secrets.yaml and are read by the capability itself. The workflow already
+# injected this token into secrets.yaml before starting the container; writing
+# it here would race the JVM, since binds are resolved once and for all at
+# capability construction.
+TOKEN="${MCP_SERVER_TOKEN}"
+
+# ── 2. Wait for readiness ─────────────────────────────────────────────
+assert_ready mcp "$PORT" "$TOKEN"
+
+# ── 3. Tests ──────────────────────────────────────────────────────────
+
+echo ""
+echo "── basic ────────────────────────────────────────────────────────"
+
+run_mcp_test "basic-list-ships" "basic-list-ships" "$PORT" '{}' "$TOKEN" \
+  'type == "array"' 'length > 0' '.[0] | has("imo")'
+
+run_mcp_test "basic-list-ships-filtered" "basic-list-ships" "$PORT" '{"status":"active"}' "$TOKEN" \
+  'type == "array"' 'all(.[]; .status == "active")'
+
+run_mcp_test "basic-get-ship" "basic-get-ship" "$PORT" '{"imo":"IMO-9321483"}' "$TOKEN" \
+  'type == "object"' '.imo == "IMO-9321483"' '.name | length > 0'
+
+run_mcp_expect_error "basic-rejects-wrong-credentials" \
+  "basic-bad-credentials" "$PORT" '{}' "$TOKEN"
+
+# Regression test for naftiko/ikanos#707: a basic-auth consumes entry with a
+# username but no `password` field used to NPE in
+# HttpClientAdapter.setChallengeResponse() instead of sending an empty
+# password. The upstream account behind this call (see authgw/htpasswd) has an
+# empty password, so this only succeeds if the fix actually sends one.
+run_mcp_test "basic-omitted-password-sends-empty-password" "basic-nopass-list-ships" "$PORT" '{}' "$TOKEN" \
+  'type == "array"' 'length > 0' '.[0] | has("imo")'
+
+echo ""
+echo "── apikey ───────────────────────────────────────────────────────"
+
+run_mcp_test "apikey-header-list-ships" "apikey-header-list-ships" "$PORT" '{}' "$TOKEN" \
+  'type == "array"' 'length > 0' '.[0] | has("imo")'
+
+run_mcp_test "apikey-header-list-ships-filtered" "apikey-header-list-ships" "$PORT" '{"status":"active"}' "$TOKEN" \
+  'type == "array"' 'all(.[]; .status == "active")'
+
+run_mcp_test "apikey-query-get-ship" "apikey-query-get-ship" "$PORT" '{"imo":"IMO-9321483"}' "$TOKEN" \
+  'type == "object"' '.imo == "IMO-9321483"' '.name | length > 0'
+
+run_mcp_expect_error "apikey-rejects-wrong-key" \
+  "apikey-bad-key" "$PORT" '{}' "$TOKEN"
+
+#RED : regression test for the apikey/Authorization bug.
+# Restlet reserves the Authorization header and refuses the write with a WARN
+run_mcp_test "apikey-authorization-header-list-ships" "apikey-authorization-list-ships" "$PORT" '{}' "$TOKEN" \
+  'type == "array"' 'length > 0' '.[0] | has("imo")'
+
+echo ""
+echo "── digest (now red : see capability.yml) ────────────────────"
+
+run_mcp_test "digest-list-ships" "digest-list-ships" "$PORT" '{}' "$TOKEN" \
+  'type == "array"' 'length > 0' '.[0] | has("imo")'
+
+run_mcp_test "digest-list-ships-filtered" "digest-list-ships" "$PORT" '{"status":"active"}' "$TOKEN" \
+  'type == "array"' 'all(.[]; .status == "active")'
+
+run_mcp_test "digest-get-ship" "digest-get-ship" "$PORT" '{"imo":"IMO-9321483"}' "$TOKEN" \
+  'type == "object"' '.imo == "IMO-9321483"' '.name | length > 0'
+
+# NOTE: this one currently passes for the wrong reason — every digest call
+# fails, so "rejected" is indistinguishable from "broken". It regains its
+# discriminating power only once the handshake works. Do not read it as
+# coverage until then.
+run_mcp_expect_error "digest-rejects-wrong-credentials" \
+  "digest-bad-credentials" "$PORT" '{}' "$TOKEN"
+
+# ── 4. Summary ────────────────────────────────────────────────────────
+print_summary
+[ "$FAILED" -gt 0 ] && exit 1 || exit 0

--- a/.github/e2e/resources/shared/secrets.yaml
+++ b/.github/e2e/resources/shared/secrets.yaml
@@ -2,3 +2,24 @@ registry-bearer-token: "dummy-token"
 registry-api-version: "1.0.0-alpha2"
 dockyard-api-key: "dummy-dockyard-key"
 mcp-server-token: "placeholder"
+
+# Credentials expected by the authgw reverse proxy (see authgw/httpd.conf).
+# These must stay in sync with authgw/htpasswd and authgw/htdigest.
+authgw-basic-user: "e2e-basic-user"
+authgw-basic-password: "e2e-basic-pass"
+authgw-apikey: "e2e-apikey-value"
+authgw-authorization-key: "e2e-raw-token-value"
+authgw-digest-user: "e2e-digest-user"
+authgw-digest-password: "e2e-digest-pass"
+
+# Basic-auth account with an empty password (see authgw/htpasswd) — regression
+# fixture for naftiko/ikanos#707: `type: basic` with a username but no
+# `password` field used to NPE in HttpClientAdapter.setChallengeResponse()
+# instead of sending an empty password.
+authgw-basic-nopass-user: "e2e-basic-nopass-user"
+
+# Deliberately wrong values, used by the negative tests to check that a
+# rejected upstream credential surfaces as a tool error rather than data.
+authgw-bad-user: "not-a-user"
+authgw-bad-password: "not-a-password"
+authgw-bad-apikey: "not-a-key"

--- a/.github/workflows/e2e-feature-tests.yml
+++ b/.github/workflows/e2e-feature-tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           docker compose \
             -f .github/e2e/resources/docker-compose.yml \
-            up -d microcks keycloak
+            up -d microcks keycloak authgw
         env:
           COMPOSE_PROJECT_NAME: ikanos-e2e
 
@@ -61,6 +61,22 @@ jobs:
             fi
             echo "  attempt $i/36 – retrying in 5s..."; sleep 5
             [ "$i" -eq 36 ] && { docker compose -f .github/e2e/resources/docker-compose.yml logs keycloak; exit 1; }
+          done
+
+      # authgw fronts Microcks with one authenticated vhost per consumed auth
+      # type. /authgw-health is the only unauthenticated path on each vhost.
+      - name: Wait for authgw
+        run: |
+          echo "Waiting for authgw..."
+          for i in $(seq 1 24); do
+            if curl -sf http://localhost:8090/authgw-health > /dev/null \
+            && curl -sf http://localhost:8091/authgw-health > /dev/null \
+            && curl -sf http://localhost:8092/authgw-health > /dev/null \
+            && curl -sf http://localhost:8093/authgw-health > /dev/null; then
+              echo "authgw is up (8090 basic, 8091 apikey, 8092 digest, 8093 raw-authorization)"; break
+            fi
+            echo "  attempt $i/24 – retrying in 5s..."; sleep 5
+            [ "$i" -eq 24 ] && { docker compose -f .github/e2e/resources/docker-compose.yml logs authgw; exit 1; }
           done
 
       - name: Import OpenAPI specs into Microcks


### PR DESCRIPTION
## Related Issue

Closes #616

---

## What does this PR do?

Adds end-to-end coverage for consumed-side authentication (basic, apikey, digest) a new `consumed-auth` feature in the nightly E2E suite that launches a real Ikanos adapter and drives it against a real authenticating upstream (Microcks behind an Apache reverse proxy enforcing basic/apikey/digest), instead of only unit-level mocks.

Each auth type is exercised as a correct/wrong-credentials pair, since the negative half is what proves the positive half actually checked anything.

---

## Tests

New `consumed-auth` feature (`.github/e2e/resources/features/consumed-auth/`), covering:

**Basic auth**
- [x] List ships with correct credentials
- [x] List ships filtered by status with correct credentials
- [x] Get a single ship with correct credentials
- [x] Wrong credentials are rejected (401 surfaces as a tool error)
- [x] Username with no `password` field sends an empty password instead of crashing (#707 regression)

**API key auth**
- [x] Key sent as the `X-Api-Key` header
- [x] Key sent as the `X-Api-Key` header, filtered by status
- [x] Key sent as the `api_key` query parameter
- [x] Wrong key is rejected (401 surfaces as a tool error)
- [ ] Key sent as a raw token in the `Authorization` header (currently red, Restlet silently drops the header (fix in #716, not yet merged))

**Digest auth**
- [ ] List ships with correct credentials( currently red, engine doesn't perform the real RFC 2617 handshake yet (documented in `capability.yml`))
- [ ] List ships filtered by status with correct credentials, same gap
- [ ] Get a single ship with correct credentials, same gap
- [x] Wrong credentials are rejected (passes today, but only because every digest call fails regardless of credentials see note in `capability.yml`)

---

## Documentation

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
