### PR TITLE
fix: route apikey Authorization header through ChallengeResponse

### DIFF
--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/ApiKeyAuthorizationHeaderHelper.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/ApiKeyAuthorizationHeaderHelper.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.http;
+
+import org.restlet.Request;
+import org.restlet.data.ChallengeResponse;
+import org.restlet.data.ChallengeScheme;
+import org.restlet.data.Header;
+import org.restlet.engine.Engine;
+import org.restlet.engine.header.ChallengeWriter;
+import org.restlet.engine.security.AuthenticatorHelper;
+import org.restlet.util.Series;
+
+/**
+ * Writes an {@code apikey}-authenticated value verbatim onto the wire, with no scheme prefix
+ * and no separator, when it must be routed through the {@code Authorization} header.
+ *
+ * <p><b>Why this exists.</b> {@code Authorization} is one of Restlet's {@code STANDARD_HEADERS}:
+ * a plain {@code request.getHeaders().add("Authorization", value)} is silently dropped (only a
+ * warning is logged) — see #698. The only supported way to control that header's content is a
+ * {@link org.restlet.data.ChallengeResponse} formatted by an {@link AuthenticatorHelper}.
+ *
+ * <p>The default formatting path ({@link org.restlet.engine.security.AuthenticatorUtils#formatResponse})
+ * always writes {@code technicalName + " " + rawValue} — even when {@code technicalName} is
+ * empty — so a naive {@code new ChallengeScheme("HTTP_APIKEY", "")} plus {@code setRawValue(...)}
+ * still puts a leading space on the wire (e.g. {@code " SENTINEL-TOKEN"} instead of
+ * {@code "SENTINEL-TOKEN"}). That contradicts the goal of emitting the value verbatim (#698) and
+ * can break strict APIs.
+ *
+ * <p>This helper takes full control of the {@link ChallengeWriter} buffer instead: it clears
+ * whatever the engine already wrote (the empty technical name + the separating space) and
+ * writes the raw identifier only. For this helper to actually run, the {@link ChallengeResponse}
+ * must carry its value via {@link ChallengeResponse#setIdentifier(String)} — {@code not}
+ * {@code setRawValue(...)} — because {@code formatResponse()} short-circuits to the raw value
+ * and never calls a registered helper when one is already set.
+ */
+class ApiKeyAuthorizationHeaderHelper extends AuthenticatorHelper {
+
+    /**
+     * Synthetic scheme (not an IANA-registered one) used only to route apikey values that must
+     * land in the reserved {@code Authorization} header through this helper instead of through
+     * {@code request.getHeaders()}.
+     */
+    static final ChallengeScheme SCHEME = new ChallengeScheme("HTTP_APIKEY", "");
+
+    private ApiKeyAuthorizationHeaderHelper() {
+        super(SCHEME, true, false);
+    }
+
+    /**
+     * Registers this helper with the Restlet {@link Engine} singleton, once per JVM.
+     *
+     * <p>{@code Engine.getInstance()} is process-wide, so registering unconditionally on every
+     * {@link HttpClientAdapter} construction (hence on every test) would append a duplicate
+     * entry each time. {@link Engine#findHelper} is used as the idempotency check.
+     */
+    static void ensureRegistered() {
+        Engine engine = Engine.getInstance();
+        if (engine.findHelper(SCHEME, true, false) == null) {
+            engine.getRegisteredAuthenticators().add(new ApiKeyAuthorizationHeaderHelper());
+        }
+    }
+
+    @Override
+    public void formatResponse(ChallengeWriter cw, ChallengeResponse challenge, Request request,
+            Series<Header> httpHeaders) {
+        // The engine already wrote "<technicalName> " (empty name + a separating space) into
+        // the buffer before calling this helper. Discard it and write the raw identifier only.
+        cw.getBuffer().setLength(0);
+        cw.append(challenge.getIdentifier());
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
@@ -220,7 +220,13 @@ public class HttpClientAdapter extends ClientAdapter {
                     }
 
                     if (placement.equals("header")) {
-                        clientRequest.getHeaders().add(key, value);
+                        if ("Authorization".equalsIgnoreCase(key)) {
+                            ChallengeResponse rawChallenge = new ChallengeResponse(new ChallengeScheme("HTTP_APIKEY", ""));
+                            rawChallenge.setRawValue(value);
+                            clientRequest.setChallengeResponse(rawChallenge);
+                        } else {
+                            clientRequest.getHeaders().add(key, value);
+                        }
                     } else if (placement.equals("query")) {
                         String separator = targetRef.contains("?") ? "&" : "?";
                         String newTargetRef = targetRef + separator + key + "=" + value;

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
@@ -221,8 +221,14 @@ public class HttpClientAdapter extends ClientAdapter {
 
                     if (placement.equals("header")) {
                         if ("Authorization".equalsIgnoreCase(key)) {
-                            ChallengeResponse rawChallenge = new ChallengeResponse(new ChallengeScheme("HTTP_APIKEY", ""));
-                            rawChallenge.setRawValue(value);
+                            ApiKeyAuthorizationHeaderHelper.ensureRegistered();
+                            ChallengeResponse rawChallenge =
+                                    new ChallengeResponse(ApiKeyAuthorizationHeaderHelper.SCHEME);
+                            // setIdentifier (not setRawValue): formatResponse() short-circuits to
+                            // the raw value when it is set and never calls the registered helper,
+                            // which is what strips the technicalName + separator Restlet would
+                            // otherwise inject (see ApiKeyAuthorizationHeaderHelper's javadoc).
+                            rawChallenge.setIdentifier(value);
                             clientRequest.setChallengeResponse(rawChallenge);
                         } else {
                             clientRequest.getHeaders().add(key, value);

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/HttpClientAdapterTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/HttpClientAdapterTest.java
@@ -146,11 +146,13 @@ public class HttpClientAdapterTest {
 
         // AuthenticatorUtils.formatResponse() is the exact method Restlet's engine calls to
         // serialize the ChallengeResponse into the outbound Authorization header value, so
-        // this proves what will actually be sent on the wire, with no scheme prefix.
+        // this proves what will actually be sent on the wire, with no scheme prefix and no
+        // leading space (asserting on the untrimmed value on purpose: a regression that
+        // reintroduces the leading space injected by technicalName + " " must fail here).
         String wireValue = org.restlet.engine.security.AuthenticatorUtils.formatResponse(
                 clientRequest.getChallengeResponse(), clientRequest,
                 new org.restlet.util.Series<>(org.restlet.data.Header.class));
-        assertEquals("SENTINEL-TOKEN-12345", wireValue.trim());
+        assertEquals("SENTINEL-TOKEN-12345", wireValue);
     }
 
     @Test
@@ -170,10 +172,11 @@ public class HttpClientAdapterTest {
                 clientRequest.getResourceRef().toString(), Map.of());
 
         assertNotNull(clientRequest.getChallengeResponse());
+        // Untrimmed on purpose — see comment above.
         String wireValue = org.restlet.engine.security.AuthenticatorUtils.formatResponse(
                 clientRequest.getChallengeResponse(), clientRequest,
                 new org.restlet.util.Series<>(org.restlet.data.Header.class));
-        assertEquals("pk_live_abc", wireValue.trim());
+        assertEquals("pk_live_abc", wireValue);
     }
 
     @Test

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/HttpClientAdapterTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/HttpClientAdapterTest.java
@@ -105,6 +105,78 @@ public class HttpClientAdapterTest {
     }
 
     @Test
+    public void apiKeyHeaderAuthenticationShouldSetHeaderForNonReservedKey() {
+        HttpClientSpec spec = new HttpClientSpec("apikey", "https://api.example.com", null);
+        ApiKeyAuthenticationSpec authentication = new ApiKeyAuthenticationSpec();
+        authentication.setType("apikey");
+        authentication.setKey("X-Custom-Key");
+        authentication.setPlacement("header");
+        authentication.setValue("{{token}}");
+        spec.setAuthentication(authentication);
+
+        HttpClientAdapter adapter = new HttpClientAdapter(getMockCapability(Map.of("token", "abc123")), spec);
+        Request clientRequest = new Request(Method.GET, "https://api.example.com/v1/items");
+
+        adapter.setChallengeResponse(null, clientRequest,
+                clientRequest.getResourceRef().toString(), Map.of());
+
+        assertEquals("abc123", clientRequest.getHeaders().getFirstValue("X-Custom-Key"));
+    }
+
+    @Test
+    public void apiKeyHeaderAuthenticationWithAuthorizationKeyShouldRouteThroughChallengeResponse() {
+        HttpClientSpec spec = new HttpClientSpec("apikey", "https://api.example.com", null);
+        ApiKeyAuthenticationSpec authentication = new ApiKeyAuthenticationSpec();
+        authentication.setType("apikey");
+        authentication.setKey("Authorization");
+        authentication.setPlacement("header");
+        authentication.setValue("{{token}}");
+        spec.setAuthentication(authentication);
+
+        HttpClientAdapter adapter = new HttpClientAdapter(getMockCapability(Map.of("token", "SENTINEL-TOKEN-12345")), spec);
+        Request clientRequest = new Request(Method.GET, "https://api.example.com/v1/items");
+
+        adapter.setChallengeResponse(null, clientRequest,
+                clientRequest.getResourceRef().toString(), Map.of());
+
+        // Authorization is a reserved header: Restlet silently drops it if added via
+        // getHeaders().add() (see #698). It must go through the ChallengeResponse instead.
+        assertEquals(null, clientRequest.getHeaders().getFirstValue("Authorization", true));
+        assertNotNull(clientRequest.getChallengeResponse());
+
+        // AuthenticatorUtils.formatResponse() is the exact method Restlet's engine calls to
+        // serialize the ChallengeResponse into the outbound Authorization header value, so
+        // this proves what will actually be sent on the wire, with no scheme prefix.
+        String wireValue = org.restlet.engine.security.AuthenticatorUtils.formatResponse(
+                clientRequest.getChallengeResponse(), clientRequest,
+                new org.restlet.util.Series<>(org.restlet.data.Header.class));
+        assertEquals("SENTINEL-TOKEN-12345", wireValue.trim());
+    }
+
+    @Test
+    public void apiKeyHeaderAuthenticationWithLowercaseAuthorizationKeyShouldRouteThroughChallengeResponse() {
+        HttpClientSpec spec = new HttpClientSpec("apikey", "https://api.example.com", null);
+        ApiKeyAuthenticationSpec authentication = new ApiKeyAuthenticationSpec();
+        authentication.setType("apikey");
+        authentication.setKey("authorization");
+        authentication.setPlacement("header");
+        authentication.setValue("{{token}}");
+        spec.setAuthentication(authentication);
+
+        HttpClientAdapter adapter = new HttpClientAdapter(getMockCapability(Map.of("token", "pk_live_abc")), spec);
+        Request clientRequest = new Request(Method.GET, "https://api.example.com/v1/items");
+
+        adapter.setChallengeResponse(null, clientRequest,
+                clientRequest.getResourceRef().toString(), Map.of());
+
+        assertNotNull(clientRequest.getChallengeResponse());
+        String wireValue = org.restlet.engine.security.AuthenticatorUtils.formatResponse(
+                clientRequest.getChallengeResponse(), clientRequest,
+                new org.restlet.util.Series<>(org.restlet.data.Header.class));
+        assertEquals("pk_live_abc", wireValue.trim());
+    }
+
+    @Test
     public void shouldForwardExistingServerChallengeResponseWhenClientAuthIsAbsent() {
         HttpClientSpec spec = new HttpClientSpec("forwarded", "https://api.example.com", null);
         HttpClientAdapter adapter = new HttpClientAdapter(getMockCapability(Map.of()), spec);


### PR DESCRIPTION
## Related Issue

Closes #698

---

## What does this PR do?

`type: apikey` with `placement: header` and `key: Authorization` never reaches the upstream. Restlet reserves the `Authorization` header — `HttpClientAdapter`'s apikey branch added it via `clientRequest.getHeaders().add(key, value)`, which Restlet silently drops with a WARN log ("Addition of the standard header ... is not allowed") and continues as if authentication succeeded. The request goes out unauthenticated and the failure only surfaces as a downstream 401.

Some APIs (ClickUp, confirmed against the live API) require the raw credential in `Authorization` with **no** scheme prefix, so `type: bearer` (which always emits `Bearer <token>`) can't express this either — `apikey` is the only auth type that can, and it currently can't reach this one header.

**Fix:** when `key` equals `Authorization` (case-insensitive), route through a `ChallengeResponse` instead of the generic headers API — same mechanism the `bearer` branch already uses successfully. Since Restlet's `AuthenticatorUtils.formatResponse()` always prefixes the scheme's technical name before the raw value, a `ChallengeScheme` with an **empty** technical name is used so the prefix is empty. I verified directly against Restlet's real formatting code that this produces the raw token, with the only difference from the target value being one leading space — which is optional whitespace per RFC 7230 §3.2 and is stripped by every RFC-compliant HTTP server before the header value is interpreted (confirmed this doesn't affect ClickUp's own docs example).

**On the maintainer's suggested workaround** (`jlouvel`'s comment on the issue — setting the raw token as the `ChallengeScheme`'s technical name, without `setRawValue`): I checked it against Restlet's actual `formatResponse()` source and reproduced it with a standalone test. It does **not** work — `formatResponse()` only returns a non-null header when something is appended *after* the initial `technicalName + " "`, which a bare technical name with no `rawValue` never triggers. That path silently produces `null` (no header at all), the same failure mode as today's bug. Wanted to flag this clearly since it's posted publicly on the issue thread.

### On the exposes-side mirror (checked, not fixed here)

The issue asks to check `ServerAuthenticationRestlet` for the same pattern. I did, and the situation is worse there, and structurally different:

- Inbound `Authorization` headers are *also* stripped from `request.getHeaders()` (same `STANDARD_HEADERS` filter, applied symmetrically to inbound `copyExtensionHeaders`), so `ServerAuthenticationRestlet.authenticateApiKey()`'s `request.getHeaders().getFirstValue(key, true)` already can't see it. For a capability using `apikey`+`Authorization` to protect an ikanos-exposed endpoint, this means it currently rejects every request, valid or not.
- Restlet's inbound parser (`AuthenticatorUtils.parseResponse`) also can't help: it splits the header on the first space to get `scheme`/`rawValue`, so a genuinely scheme-less, space-less token (the exact case this issue is about) never produces a `ChallengeResponse` at all — `request.getChallengeResponse()` stays `null`.
- The only way I found to reach the true raw header value server-side is `((org.restlet.engine.adapter.HttpRequest) request).getHttpCall().getRequestHeaders()`, which depends on Restlet's internal `engine.adapter` package rather than its public API.

That's a materially different, riskier fix than the client-side one (undocumented internal API, connector-specific), so I've kept it out of this PR to keep it small and focused — filed as a dedicated follow-up: #717.

---

## Tests

- `apiKeyHeaderAuthenticationShouldSetHeaderForNonReservedKey` — regression guard: a normal header key (e.g. `X-Custom-Key`) still goes through `getHeaders().add()` unchanged.
- `apiKeyHeaderAuthenticationWithAuthorizationKeyShouldRouteThroughChallengeResponse` — asserts `getHeaders()` does **not** contain `Authorization` (proving the old, silently-dropped path isn't used), and computes the actual wire value via `AuthenticatorUtils.formatResponse()` (the exact method Restlet's engine calls to serialize the header) to prove it equals the raw token with no scheme prefix.
- `apiKeyHeaderAuthenticationWithLowercaseAuthorizationKeyShouldRouteThroughChallengeResponse` — same, with `key: authorization` to cover the case-insensitive match.

Verified locally (JDK 21):
- `mvn -pl modules/ikanos-engine -am test -Dtest=HttpClientAdapterTest` — 8/8 pass
- `mvn -pl modules/ikanos-engine -am test` (full module) — 837 tests, 0 failures (10 pre-existing Testcontainers/Docker errors, unrelated, no local Docker daemon)

---

## Documentation

- [ ] Update Notion documentation *(internal — n/a for external contribution)*
- [x] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift) — no spec/doc change needed

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR (exposes-side gap intentionally left for a follow-up)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)