### PR TITLE
feat: sync of nightly quality gate fixes

### DIFF
--- a/.github/workflows/nightly-orchestrator.yml
+++ b/.github/workflows/nightly-orchestrator.yml
@@ -17,11 +17,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCHES=$(gh api repos/${{ github.repository }}/pulls \
-            --jq '[.[] | .head.ref] + ["main"] | unique | .[]')
+          BRANCHES=$(gh api --paginate repos/${{ github.repository }}/pulls | jq -s '
+            [.[][] | select(.head.repo.fork == false) | .head.ref] + ["main"] | unique | .[]
+          ')
 
+          FAILED=""
           for BRANCH in $BRANCHES; do
             echo "Dispatching nightly on branch: $BRANCH"
-            gh api repos/${{ github.repository }}/actions/workflows/nightly-quality-gate.yml/dispatches \
-              -f ref="$BRANCH"
+            if ! gh api repos/${{ github.repository }}/actions/workflows/nightly-quality-gate.yml/dispatches \
+              -f ref="$BRANCH"; then
+              echo "::error::Failed to dispatch nightly quality gate on branch: $BRANCH"
+              FAILED="$FAILED $BRANCH"
+            fi
           done
+
+          if [ -n "$FAILED" ]; then
+            echo "::error::Dispatch failed for:$FAILED"
+            exit 1
+          fi

--- a/.github/workflows/nightly-quality-gate.yml
+++ b/.github/workflows/nightly-quality-gate.yml
@@ -11,6 +11,9 @@ jobs:
   test-and-analyze:
     name: Unit Tests + JaCoCo + SonarQube + Security
     runs-on: ubuntu-latest
+    outputs:
+      trivy_critical: ${{ steps.trivy-summary.outputs.trivy_critical }}
+      trivy_high: ${{ steps.trivy-summary.outputs.trivy_high }}
 
     steps:
       - uses: actions/checkout@v7
@@ -282,6 +285,7 @@ jobs:
           exit-code: '0'
 
       - name: Publish Trivy summary
+        id: trivy-summary
         if: always()
         run: |
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -296,6 +300,8 @@ jobs:
           TRIVY_MEDIUM=0
           TRIVY_LOW=0
           EOF
+            echo "trivy_critical=0" >> "$GITHUB_OUTPUT"
+            echo "trivy_high=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -338,6 +344,9 @@ jobs:
           TRIVY_MEDIUM=$MEDIUM
           TRIVY_LOW=$LOW
           EOF
+
+          echo "trivy_critical=$CRITICAL" >> "$GITHUB_OUTPUT"
+          echo "trivy_high=$HIGH" >> "$GITHUB_OUTPUT"
 
       - name: Upload Trivy report
         uses: actions/upload-artifact@v7
@@ -565,8 +574,8 @@ jobs:
             echo "| Integration Tests | ${{ needs.integration-tests.result }} |" >> $GITHUB_STEP_SUMMARY
             echo "| CLI Smoke Tests | ${{ needs.smoke-tests.result }} |" >> $GITHUB_STEP_SUMMARY
             
-  notify-on-failure:
-      name: Slack notification on failure
+  notify-on-failure-or-vulnerabilities:
+      name: Slack notification on failure or vulnerability finding
       needs:
         - test-and-analyze
         - integration-tests
@@ -575,16 +584,26 @@ jobs:
         always() && !startsWith(github.ref_name, 'dependabot/') && (
           needs.test-and-analyze.result == 'failure' ||
           needs.integration-tests.result == 'failure' ||
-          needs.smoke-tests.result == 'failure'
+          needs.smoke-tests.result == 'failure' ||
+          needs.test-and-analyze.outputs.trivy_critical > 0 ||
+          needs.test-and-analyze.outputs.trivy_high > 0
         )
       runs-on: ubuntu-latest
       steps:
         - name: Send Slack notification
+          env:
+            PIPELINE_FAILED: ${{ needs.test-and-analyze.result == 'failure' || needs.integration-tests.result == 'failure' || needs.smoke-tests.result == 'failure' }}
           run: |
+            if [ "$PIPELINE_FAILED" = "true" ]; then
+              TEXT="❌ *Nightly Quality Gate failed*"
+            else
+              TEXT="⚠️ *Nightly Quality Gate: vulnerabilities found on an otherwise green run*"
+            fi
+
             curl -s -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
               -H "Content-Type: application/json" \
               -d '{
-                "text": "❌ *Nightly Quality Gate failed*",
+                "text": "'"$TEXT"'",
                 "attachments": [
                   {
                     "color": "danger",
@@ -593,7 +612,9 @@ jobs:
                       { "title": "Branch", "value": "${{ github.ref_name }}", "short": true },
                       { "title": "Quality Gate", "value": "${{ needs.test-and-analyze.result }}", "short": true },
                       { "title": "Integration Tests", "value": "${{ needs.integration-tests.result }}", "short": true },
-                      { "title": "CLI Smoke Tests", "value": "${{ needs.smoke-tests.result }}", "short": true }
+                      { "title": "CLI Smoke Tests", "value": "${{ needs.smoke-tests.result }}", "short": true },
+                      { "title": "Trivy Critical", "value": "${{ needs.test-and-analyze.outputs.trivy_critical }}", "short": true },
+                      { "title": "Trivy High", "value": "${{ needs.test-and-analyze.outputs.trivy_high }}", "short": true }
                     ],
                     "actions": [
                       {


### PR DESCRIPTION
## Related Issue

no related issue

---

## What does this PR do?

Fixes reliability issues in the nightly dispatch/alerting, found in review of the same setup on `shipyard` (naftiko/shipyard#251):

- `nightly-orchestrator.yml`: pagination missing on the PR list (`--paginate`), fork PRs would fail to dispatch (now filtered out), and a failed dispatch was silently swallowed (now collected + step fails if any branch fails).
- `nightly-quality-gate.yml`: Trivy's `exit-code: '0'` meant the Slack alert could never fire from a real finding. Didn't flip it to `'1'` since Trivy is a mid-job step here — that would skip the Gitleaks/metrics steps after it. Instead, exposed the existing `$CRITICAL`/`$HIGH` counts as a job output and wired that into `notify-on-failure`'s condition.

---

## Tests

<!-- Describe tests added or modified. If none, explain why. -->

---

## Documentation

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Every commit is signed off (`git commit -s`) — the [DCO](https://probot.github.io/apps/dco/) check must pass

