### PR TITLE
fix: add jq raw output flag to nightly orchestrator branch dispatch

### DIFF
--- a/.github/workflows/nightly-orchestrator.yml
+++ b/.github/workflows/nightly-orchestrator.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCHES=$(gh api --paginate repos/${{ github.repository }}/pulls | jq -s '
+          BRANCHES=$(gh api --paginate repos/${{ github.repository }}/pulls | jq -r -s '
             [.[][] | select(.head.repo.fork == false) | .head.ref] + ["main"] | unique | .[]
           ')
 


### PR DESCRIPTION
## Related Issue

No tracking issue — this is a CI-only regression fix (not an application bug), addressed directly per maintainer decision.

---

## What does this PR do?

Fixes the `Nightly Trigger` workflow (`nightly-orchestrator.yml`), which has been failing to dispatch the nightly quality gate on every branch (including `main`) since commit `4e4536b9` ("feat: sync of nightly quality gate fixes", merged 2026-08-27).

**Root cause**: the `jq -s '...'` pipeline that lists branch names to dispatch on was missing the `-r` (raw-output) flag. Without it, `jq` emits each branch name as a JSON-quoted string (e.g. `"main"` with literal quotes), which was then passed as `-f ref="$BRANCH"` to the workflow-dispatch API call. GitHub then looks for a ref literally named `"main"` (quotes included) and fails with HTTP 422 `No ref found for: "main"` — for every branch, every night.

**Fix**: add `-r` to the `jq -s` call so branch names are emitted as raw text, matching the behavior of the previous (pre-regression) implementation that used `gh api --jq` instead of a piped `jq -s`.

See failing run: https://github.com/naftiko/ikanos/actions/runs/33145399689/job/98765168886

---

## Tests

No automated test coverage exists for this orchestrator workflow (it's a thin dispatch script, not application code). Validated locally by replaying the `jq` pipeline against a representative JSON payload with `-r` and confirming branch names are emitted without surrounding quotes. Will also confirm via the next scheduled/dispatched run of `Nightly Trigger` once merged.

---

## Documentation

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

Not applicable — this is an internal CI script fix with no user-facing or spec impact.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Every commit is signed off (`git commit -s`) — the [DCO](https://probot.github.io/apps/dco/) check must pass

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko - Claude Sonnet 5
tool: VS Code Copilot Chat
confidence: high
source_event: user_reported_failing_nightly_run
discovery_method: user_report
review_focus: .github/workflows/nightly-orchestrator.yml
```
