### PR TITLE
chore: add permissions and update property

### DIFF
--- a/.github/workflows/bump-next-versions.yml
+++ b/.github/workflows/bump-next-versions.yml
@@ -12,6 +12,14 @@ on:
         required: false
         type: string
 
+# No secrets.GITHUB_TOKEN is used in this workflow (a GitHub App token is minted
+# instead for checkout/push/PR creation), so this is not an active privilege-escalation
+# risk. Declared explicitly anyway for consistency with this repo's other workflows
+# (quality-gate.yml, nightly-*.yml, publish-*.yml), which all set least-privilege
+# permissions rather than relying on the repository/org default.
+permissions:
+  contents: read
+
 jobs:
   bump-next-versions:
     runs-on: ubuntu-latest
@@ -25,7 +33,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.APP_SYNC_IKANOS_VERSION_ID }}
+          client-id: ${{ secrets.APP_SYNC_IKANOS_VERSION_ID }}
           private-key: ${{ secrets.APP_SYNC_IKANOS_VERSION_PRIVATE_KEY }}
 
       - name: Checkout code


### PR DESCRIPTION
## Related Issue

No related issue

---

## What does this PR do?

Update the bump-next-versions GitHub action:
- Add permissions
- replace app-id property (deprecated) by client-id

---

## Tests

<!-- Describe tests added or modified. If none, explain why. -->

---

## Documentation

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Every commit is signed off (`git commit -s`) — the [DCO](https://probot.github.io/apps/dco/) check must pass

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
